### PR TITLE
feat: update sponsor levels with new tiers and amounts

### DIFF
--- a/supabase/migrations/20240225_005_update_sponsor_levels.sql
+++ b/supabase/migrations/20240225_005_update_sponsor_levels.sql
@@ -1,11 +1,14 @@
 -- First, add the amount column to the sponsor_levels table
 ALTER TABLE api.sponsor_levels ADD COLUMN IF NOT EXISTS amount INTEGER NOT NULL DEFAULT 0;
 
--- Remove all existing sponsor levels
-DELETE FROM api.sponsor_levels;
+-- Create a temporary table to store the new levels
+CREATE TEMP TABLE temp_sponsor_levels (
+    name TEXT NOT NULL,
+    amount INTEGER NOT NULL
+);
 
--- Insert new sponsor levels with their amounts
-INSERT INTO api.sponsor_levels (name, amount) VALUES
+-- Insert the new levels into the temporary table
+INSERT INTO temp_sponsor_levels (name, amount) VALUES
     ('Champion', 5000),
     ('Eagle', 2500),
     ('Golf Gift', 2500),
@@ -17,5 +20,38 @@ INSERT INTO api.sponsor_levels (name, amount) VALUES
     ('Chick-Fil-A AM', 500),
     ('Bojangles PM', 500);
 
--- Update the updated_at timestamp
+-- Create a mapping table for old to new levels (using the lowest amount as default)
+CREATE TEMP TABLE level_mapping AS
+SELECT 
+    old.id as old_id,
+    new.id as new_id
+FROM api.sponsor_levels old
+CROSS JOIN LATERAL (
+    SELECT id 
+    FROM api.sponsor_levels new
+    WHERE new.amount = (
+        SELECT MIN(amount) 
+        FROM temp_sponsor_levels
+    )
+    LIMIT 1
+) new;
+
+-- Update any existing sponsors to use the mapped levels
+UPDATE api.sponsors
+SET level = level_mapping.new_id
+FROM level_mapping
+WHERE level = level_mapping.old_id;
+
+-- Now safe to delete old levels
+DELETE FROM api.sponsor_levels;
+
+-- Insert new sponsor levels
+INSERT INTO api.sponsor_levels (name, amount)
+SELECT name, amount FROM temp_sponsor_levels;
+
+-- Update timestamps
 UPDATE api.sponsor_levels SET updated_at = NOW();
+
+-- Clean up temporary tables
+DROP TABLE temp_sponsor_levels;
+DROP TABLE level_mapping;

--- a/supabase/migrations/20240225_005_update_sponsor_levels.sql
+++ b/supabase/migrations/20240225_005_update_sponsor_levels.sql
@@ -1,0 +1,21 @@
+-- First, add the amount column to the sponsor_levels table
+ALTER TABLE api.sponsor_levels ADD COLUMN IF NOT EXISTS amount INTEGER NOT NULL DEFAULT 0;
+
+-- Remove all existing sponsor levels
+DELETE FROM api.sponsor_levels;
+
+-- Insert new sponsor levels with their amounts
+INSERT INTO api.sponsor_levels (name, amount) VALUES
+    ('Champion', 5000),
+    ('Eagle', 2500),
+    ('Golf Gift', 2500),
+    ('Celebration Lunch', 2500),
+    ('Bloody Mary', 1000),
+    ('Golf Cart', 1000),
+    ('Celebration Wall', 700),
+    ('Thursday Night', 700),
+    ('Chick-Fil-A AM', 500),
+    ('Bojangles PM', 500);
+
+-- Update the updated_at timestamp
+UPDATE api.sponsor_levels SET updated_at = NOW();


### PR DESCRIPTION
This PR updates the sponsor levels in the database with new tiers and their corresponding amounts.

Changes:
- Added 'amount' column to sponsor_levels table
- Removed existing sponsor levels
- Added new sponsor levels with their amounts:
  - Champion (,000)
  - Eagle (,500)
  - Golf Gift (,500)
  - Celebration Lunch (,500)
  - Bloody Mary (,000)
  - Golf Cart (,000)
  - Celebration Wall ()
  - Thursday Night ()
  - Chick-Fil-A AM ()
  - Bojangles PM ()

Note: This migration will remove all existing sponsor levels and replace them with the new ones. Make sure to update any existing sponsors to use the new level IDs if needed.