### PR TITLE
Add website URL column to sponsors table

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -12,6 +12,7 @@
    [x] Add real-time Cloudinary connection status
    [x] Add logo display in sponsor carousel
    [x] Make sponsor carousel dynamic with real data
+   [x] Add website URL field for sponsors
    [] Implement rollback mechanism if either Cloudinary or Supabase operations fail
 
 2. Authentication & Authorization

--- a/docs/features/feature-sponsor-website-column.md
+++ b/docs/features/feature-sponsor-website-column.md
@@ -1,0 +1,19 @@
+# Sponsor Website Column
+
+## Overview
+This feature adds a `website` column to the `sponsors` table in the database, allowing us to store and display website URLs for each sponsor.
+
+## Implementation Details
+- Added a new migration file (`20250227_add_website_to_sponsors.sql`) that safely adds the `website` column to the `api.sponsors` table
+- The migration is designed to be idempotent (can be run multiple times without error) by checking if the column exists before attempting to add it
+- This ensures compatibility across all environments (development, production)
+
+## Technical Considerations
+- The column is defined as `TEXT` type to accommodate URLs of any length
+- The column is nullable to maintain compatibility with existing data
+- The migration includes an undo section (commented out) that can be used to revert the change if needed
+
+## Future Enhancements
+- Add UI components to display sponsor websites
+- Add form fields to allow editing of sponsor websites
+- Consider adding URL validation

--- a/supabase/migrations/20250227_add_website_to_sponsors.sql
+++ b/supabase/migrations/20250227_add_website_to_sponsors.sql
@@ -1,0 +1,23 @@
+
+-- Migration: add_website_to_sponsors
+-- Created at: 2025-02-27
+
+-- Add website column to sponsors table if it doesn't exist
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'api'
+        AND table_name = 'sponsors'
+        AND column_name = 'website'
+    ) THEN
+        ALTER TABLE api.sponsors
+        ADD COLUMN website TEXT;
+    END IF;
+END $$;
+
+-- @UNDO
+
+-- Remove website column from sponsors table
+-- ALTER TABLE api.sponsors DROP COLUMN IF EXISTS website;


### PR DESCRIPTION
This PR adds a migration to ensure the website URL column exists in the sponsors table across all environments. The migration is designed to be safe and idempotent, checking if the column exists before attempting to add it. This ensures compatibility with both production and development environments. Documentation has been added and the ROADMAP has been updated to reflect this feature.