### PR TITLE
Add website URL column to SponsorsTable

### DIFF
--- a/components/admin/SponsorsTable.tsx
+++ b/components/admin/SponsorsTable.tsx
@@ -95,6 +95,7 @@ export default function SponsorsTable({ onAddSponsor, onEditSponsor }: SponsorsT
         name: string;
         level: string;
         year: number;
+        website_url: string | null;
         image_url: string | null;
         cloudinary_public_id: string | null;
         created_at: string;
@@ -106,6 +107,7 @@ export default function SponsorsTable({ onAddSponsor, onEditSponsor }: SponsorsT
         name: sponsor.name,
         level: sponsor.level,
         year: sponsor.year,
+        website_url: sponsor.website_url,
         image_url: sponsor.image_url,
         cloudinary_public_id: sponsor.cloudinary_public_id,
         created_at: sponsor.created_at,
@@ -221,6 +223,28 @@ export default function SponsorsTable({ onAddSponsor, onEditSponsor }: SponsorsT
       minWidth: 100,
       headerAlign: 'center',
       align: 'center',
+    },
+    {
+      field: 'website_url',
+      headerName: 'Website',
+      flex: 1,
+      minWidth: 180,
+      headerAlign: 'center',
+      align: 'center',
+      renderCell: params => {
+        const url = params.row.website_url;
+        if (!url) return '-';
+        return (
+          <a 
+            href={url} 
+            target="_blank" 
+            rel="noopener noreferrer"
+            className="text-primary hover:underline truncate max-w-full"
+          >
+            {url.replace(/^https?:\/\/(www\.)?/, '')}
+          </a>
+        );
+      },
     },
     {
       field: 'image_url',

--- a/lib/neon/improved-server-client.ts
+++ b/lib/neon/improved-server-client.ts
@@ -20,8 +20,6 @@ if (process.env.NODE_ENV === 'production') {
       
       dynamicImport('ws').then((WebSocketModule: WebSocketModule) => {
         neonConfig.webSocketConstructor = WebSocketModule.default;
-        // Enable fetch-based queries for better performance
-        neonConfig.fetchConnectionCache = true;
       }).catch((error: Error) => {
         console.warn('WebSocket import failed, falling back to HTTP-only mode:', error);
       });


### PR DESCRIPTION
This PR adds a website URL column to the SponsorsTable component and removes the deprecated fetchConnectionCache option from the Neon serverless driver configuration.