### PR TITLE
Sort sponsor levels by amount from largest to smallest

### DIFF
--- a/components/admin/AddSponsorForm.tsx
+++ b/components/admin/AddSponsorForm.tsx
@@ -70,6 +70,9 @@ export function AddSponsorForm({ onSponsorAdded, sponsorToEdit }: AddSponsorForm
           amount: level.amount
         }));
 
+        // Sort levels by amount from largest to smallest
+        transformedLevels.sort((a, b) => b.amount - a.amount);
+
         setLevels(transformedLevels);
         
         // If not in edit mode, set default level


### PR DESCRIPTION
This PR sorts the sponsor levels in the AddSponsorForm dropdown by amount from largest to smallest, making it easier for users to find higher-tier sponsorship levels.