### PR TITLE
Fix Neon branch cleanup workflow

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -26,13 +26,12 @@ jobs:
 
       - name: Delete Neon branch
         run: |
-          # Extract PR number from GITHUB_REF
-          PR_NUMBER=$(echo $GITHUB_REF | sed -n 's/refs\/pull\/\([0-9]*\)\/merge/\1/p')
-          if [ -z "$PR_NUMBER" ]; then
-            PR_NUMBER=$(echo $GITHUB_REF | sed -n 's/refs\/pull\/\([0-9]*\)\/head/\1/p')
-          fi
+          # Get PR number directly from GitHub context
+          PR_NUMBER=${{ github.event.pull_request.number }}
           
+          echo "PR Number: $PR_NUMBER"
           BRANCH_NAME="preview-pr-${PR_NUMBER}"
+          echo "Branch Name to delete: $BRANCH_NAME"
           
           # Delete the Neon branch
           node scripts/db-migration-manager.js delete-branch $BRANCH_NAME

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -33,9 +33,11 @@ jobs:
       - name: Create Neon branch
         id: create-branch
         run: |
-          # Extract PR number from GITHUB_REF
-          PR_NUMBER=$(echo $GITHUB_REF | sed -n 's/refs\/pull\/\([0-9]*\)\/merge/\1/p')
+          # Get PR number directly from GitHub context
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          echo "PR Number: $PR_NUMBER"
           BRANCH_NAME="preview-pr-${PR_NUMBER}"
+          echo "Branch Name: $BRANCH_NAME"
           
           # Create a new branch in Neon (or use existing one)
           node scripts/db-migration-manager.js create-branch main $BRANCH_NAME

--- a/scripts/cleanup-branches.js
+++ b/scripts/cleanup-branches.js
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+
+const { execSync } = require('child_process');
+const fetch = require('node-fetch');
+
+// Replace these with your actual values
+const NEON_API_KEY = process.env.NEON_API_KEY || 'YOUR_NEON_API_KEY';
+const NEON_PROJECT_ID = process.env.NEON_PROJECT_ID || 'YOUR_NEON_PROJECT_ID';
+const NEON_API_URL = 'https://console.neon.tech/api/v2';
+
+// Function to list all branches
+async function listNeonBranches() {
+  console.log('Listing Neon branches...');
+
+  try {
+    const response = await fetch(`${NEON_API_URL}/projects/${NEON_PROJECT_ID}/branches`, {
+      method: 'GET',
+      headers: {
+        'Accept': 'application/json',
+        'Authorization': `Bearer ${NEON_API_KEY}`
+      }
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json();
+      throw new Error(`Failed to list branches: ${JSON.stringify(errorData)}`);
+    }
+
+    const data = await response.json();
+    console.log('✅ Branches retrieved successfully');
+    return data.branches;
+  } catch (error) {
+    console.error('Error listing branches:', error.message);
+    return null;
+  }
+}
+
+// Function to delete a branch
+async function deleteNeonBranch(branchId) {
+  console.log(`Deleting Neon branch '${branchId}'...`);
+
+  try {
+    const response = await fetch(`${NEON_API_URL}/projects/${NEON_PROJECT_ID}/branches/${branchId}`, {
+      method: 'DELETE',
+      headers: {
+        'Accept': 'application/json',
+        'Authorization': `Bearer ${NEON_API_KEY}`
+      }
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json();
+      throw new Error(`Failed to delete branch: ${JSON.stringify(errorData)}`);
+    }
+
+    console.log('✅ Branch deleted successfully');
+    return true;
+  } catch (error) {
+    console.error('Error deleting branch:', error.message);
+    return false;
+  }
+}
+
+// Function to get closed PRs
+async function getClosedPRs() {
+  try {
+    const output = execSync('gh pr list --state closed --limit 100 --json number').toString();
+    const prs = JSON.parse(output);
+    return prs.map(pr => pr.number);
+  } catch (error) {
+    console.error('Error getting closed PRs:', error.message);
+    return [];
+  }
+}
+
+// Main function
+async function main() {
+  // Get all branches
+  const branches = await listNeonBranches();
+  if (!branches) {
+    console.error('Failed to list branches');
+    process.exit(1);
+  }
+
+  // Get all closed PRs
+  const closedPRs = await getClosedPRs();
+  console.log('Closed PRs:', closedPRs);
+
+  // Find preview branches for closed PRs
+  const branchesToDelete = branches.filter(branch => {
+    const match = branch.name.match(/^preview-pr-(\d+)$/);
+    if (match) {
+      const prNumber = parseInt(match[1], 10);
+      return closedPRs.includes(prNumber);
+    }
+    return false;
+  });
+
+  console.log(`Found ${branchesToDelete.length} branches to delete`);
+
+  // Delete each branch
+  for (const branch of branchesToDelete) {
+    console.log(`Deleting branch ${branch.name}...`);
+    await deleteNeonBranch(branch.id);
+  }
+
+  console.log('Cleanup completed!');
+}
+
+main().catch(error => {
+  console.error('Error:', error);
+  process.exit(1);
+}); 

--- a/scripts/db-migration-manager.js
+++ b/scripts/db-migration-manager.js
@@ -559,7 +559,11 @@ async function main() {
       const branchObj = branchesToDelete.find(b => b.name === branchToDelete);
       if (!branchObj) {
         console.error(`Branch '${branchToDelete}' not found`);
-        process.exit(1);
+        console.log('Available branches:');
+        branchesToDelete.forEach(b => console.log(`- ${b.name}`));
+        // Don't exit with error if branch doesn't exist - it might have been already deleted
+        console.log('Branch may have been already deleted or never existed. Continuing...');
+        process.exit(0);
       }
       
       const deleted = await deleteNeonBranch(branchObj.id);


### PR DESCRIPTION
This PR fixes the Neon branch cleanup workflow that was failing to delete preview branches after PRs were merged.\n\n## Changes:\n\n1. Fixed the PR number extraction in the cleanup workflow by using the GitHub context directly\n2. Improved error handling in the db-migration-manager.js script to handle cases where branches don't exist more gracefully\n3. Added a cleanup-branches.js script that can be used to manually clean up stale preview branches\n\n## Testing:\n\nThe workflow should now correctly delete Neon database branches when PRs are closed.