### PR TITLE
Fix: Add sponsors folder prefix to Cloudinary image URLs in carousel

### DIFF
--- a/components/SponsorCarousel.tsx
+++ b/components/SponsorCarousel.tsx
@@ -200,7 +200,7 @@ export default function SponsorCarousel() {
                         >
                           {sponsor.cloudinary_public_id ? (
                             <CldImage
-                              src={sponsor.cloudinary_public_id}
+                              src={`sponsors/${sponsor.cloudinary_public_id}`}
                               alt={`${sponsor.name} logo`}
                               fill
                               className="object-contain bg-white rounded-lg p-4 transition-all duration-300 group-hover:scale-105"

--- a/components/SponsorLightbox.tsx
+++ b/components/SponsorLightbox.tsx
@@ -64,7 +64,7 @@ export function SponsorLightbox({ isOpen, onClose, sponsor }: SponsorLightboxPro
                     <div className="relative aspect-square bg-gray-50 rounded-xl overflow-hidden">
                       {sponsor.cloudinary_public_id ? (
                         <CldImage
-                          src={sponsor.cloudinary_public_id}
+                          src={`sponsors/${sponsor.cloudinary_public_id}`}
                           alt={`${sponsor.name} logo`}
                           fill
                           className="object-contain p-8"


### PR DESCRIPTION
## Description\n\nThis PR fixes the broken sponsor logo images in the carousel and lightbox components by adding the correct Cloudinary folder prefix.\n\n### Changes\n- Updated `SponsorCarousel` to use `sponsors/${sponsor.cloudinary_public_id}` for image paths\n- Updated `SponsorLightbox` to use the same path format to maintain consistency\n- This matches the actual folder structure in Cloudinary where all sponsor logos are stored in the 'sponsors' folder\n\n### Before\n- Image URLs were missing the 'sponsors/' folder prefix\n- This caused broken images in both the carousel and lightbox views\n- Example: `cloudinary_public_id: 'lzqqezwun5zzfyr7daby'`\n\n### After\n- Image URLs now include the correct folder prefix\n- Images load correctly in both carousel and lightbox views\n- Example: `src='sponsors/lzqqezwun5zzfyr7daby'`\n\n### Testing\n- Verified that sponsor logos display correctly in the carousel\n- Verified that logos display correctly when clicking to view in the lightbox\n- Confirmed that hover effects and transitions work as expected\n\n### Related Changes\n- This complements PR #54 which fixed similar issues in the admin panel\n- Both changes ensure consistent handling of Cloudinary image paths across the application