### PR TITLE
Move SponsorsTable from Dashboard to Sponsors page

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,26 +1,6 @@
 'use client';
 
-import { useState } from 'react';
-import { Plus } from 'lucide-react';
-import { default as SponsorsTable } from '@/components/admin/SponsorsTable';
-import { Button } from '@/components/ui/button';
-import { AddSponsorDialog } from '@/components/admin/AddSponsorDialog';
-import { SponsorWithLevel } from '@/types/sponsors';
-
 export default function AdminPage() {
-  const [isAddSponsorOpen, setIsAddSponsorOpen] = useState(false);
-  const [selectedSponsor, setSelectedSponsor] = useState<SponsorWithLevel | null>(null);
-
-  const handleEditSponsor = (sponsor: SponsorWithLevel) => {
-    setSelectedSponsor(sponsor);
-    setIsAddSponsorOpen(true);
-  };
-
-  const handleCloseDialog = () => {
-    setIsAddSponsorOpen(false);
-    setSelectedSponsor(null);
-  };
-
   return (
     <div className="space-y-6">
       <div className="bg-white shadow rounded-lg p-6">
@@ -57,34 +37,6 @@ export default function AdminPage() {
           </div>
         </div>
       </div>
-
-      {/* Sponsor Management */}
-      <div className="space-y-6">
-        {/* Sponsors Table */}
-        <div className="bg-white/80 backdrop-blur-sm shadow rounded-lg p-6">
-          <div className="flex justify-between items-center mb-4">
-            <h2 className="text-xl font-medium text-gray-900">Sponsors</h2>
-            <Button onClick={() => setIsAddSponsorOpen(true)}>
-              <Plus className="h-4 w-4 mr-2" />
-              Add Sponsor
-            </Button>
-          </div>
-          <SponsorsTable 
-            onAddSponsor={() => setIsAddSponsorOpen(true)} 
-            onEditSponsor={handleEditSponsor}
-          />
-        </div>
-      </div>
-      
-      <AddSponsorDialog
-        isOpen={isAddSponsorOpen}
-        onClose={handleCloseDialog}
-        sponsorToEdit={selectedSponsor}
-        onSponsorAdded={() => {
-          // Refresh the page data when a sponsor is added or edited
-          window.location.reload();
-        }}
-      />
     </div>
   );
 }

--- a/app/admin/sponsors/page.tsx
+++ b/app/admin/sponsors/page.tsx
@@ -1,32 +1,52 @@
 'use client';
 
 import { useState } from 'react';
+import { Plus } from 'lucide-react';
 
-import { SponsorForm } from '@/components/admin/SponsorForm';
+import { default as SponsorsTable } from '@/components/admin/SponsorsTable';
+import { Button } from '@/components/ui/button';
+import { AddSponsorDialog } from '@/components/admin/AddSponsorDialog';
+import { SponsorWithLevel } from '@/types/sponsors';
 
 export default function AdminSponsorsPage() {
-  const [showForm, setShowForm] = useState(false);
+  const [isAddSponsorOpen, setIsAddSponsorOpen] = useState(false);
+  const [selectedSponsor, setSelectedSponsor] = useState<SponsorWithLevel | null>(null);
+
+  const handleEditSponsor = (sponsor: SponsorWithLevel) => {
+    setSelectedSponsor(sponsor);
+    setIsAddSponsorOpen(true);
+  };
+
+  const handleCloseDialog = () => {
+    setIsAddSponsorOpen(false);
+    setSelectedSponsor(null);
+  };
 
   return (
-    <div className="container mx-auto p-4">
-      <h1 className="mb-6 text-2xl font-bold">Sponsor Management</h1>
-      <div className="mb-4">
-        <button
-          onClick={() => setShowForm(true)}
-          className="rounded bg-blue-500 px-4 py-2 text-white hover:bg-blue-600"
-        >
-          Add New Sponsor
-        </button>
-      </div>
-
-      {showForm && (
-        <div className="mb-8">
-          <h2 className="mb-4 text-xl font-semibold">Add New Sponsor</h2>
-          <SponsorForm onSuccess={() => setShowForm(false)} />
+    <div className="space-y-6">
+      <div className="bg-white/80 backdrop-blur-sm shadow rounded-lg p-6">
+        <div className="flex justify-between items-center mb-4">
+          <h2 className="text-xl font-medium text-gray-900">Sponsors</h2>
+          <Button onClick={() => setIsAddSponsorOpen(true)}>
+            <Plus className="h-4 w-4 mr-2" />
+            Add Sponsor
+          </Button>
         </div>
-      )}
-
-      <div className="sponsors-list">{/* Sponsor list will be implemented here */}</div>
+        <SponsorsTable 
+          onAddSponsor={() => setIsAddSponsorOpen(true)} 
+          onEditSponsor={handleEditSponsor}
+        />
+      </div>
+      
+      <AddSponsorDialog
+        isOpen={isAddSponsorOpen}
+        onClose={handleCloseDialog}
+        sponsorToEdit={selectedSponsor}
+        onSponsorAdded={() => {
+          // Refresh the page data when a sponsor is added or edited
+          window.location.reload();
+        }}
+      />
     </div>
   );
 }


### PR DESCRIPTION
This PR moves the SponsorsTable component from the Dashboard to the Sponsors page in the admin interface. This improves organization by placing sponsor management functionality in its dedicated section, making the interface more intuitive and following the principle of separation of concerns.